### PR TITLE
Update addNewItem documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ noItemsFound() {
 
 ### addNewItem: Bool | String | Function
 
-_Description: Bool: whether to display 'Add new item' option or not. String: 'Add new item' label. Function: 'Add new item' renderer. You must handle onClick event via `onAddNewItem` callback or your own callback in case of custom renderer._
+_Description: Bool: whether to display 'Add new item' option or not. String: 'Add new item' label. Function: 'Add new item' renderer. You must handle onClick event via `onAddNewItem` callback or your own callback in case of custom renderer. Note: for the 'Add new item' option to display, `searchable` must be true and `options` must be empty._
 
 Default: `false`
 


### PR DESCRIPTION
This adds a very small note to the documentation regarding addNewItem, letting the user know the other conditions necessary for the option to show. I think it should eliminate some confusion around what setting addNewItem to true does. I was confused the first time I implemented it, and then had forgotten the rules when I wanted to use it again. 

Thanks a lot for this package! I'm working on a project where I have to render some really huge lists, and this helped me overcome a huge performance bottleneck I was running into with other packages.